### PR TITLE
Extend foundation with schema and basic API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
+# Workforce Plan
 
+This project serves as a starting point for building a workforce modeling application.
+Its goals are to store workforce data, forecast staffing costs, and compare them
+to allocated budgets. The codebase uses a lightweight Python stack so it can be
+run in restricted environments and gradually grow into a web service that offers
+reporting tools for human resources teams.
+
+The repository currently contains modules that will evolve into a full
+application:
+
+- `src/app.py` — entry point exposing a basic Flask server
+- `src/database.py` — utilities for connecting to a SQLite database
+
+## Getting Started
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the application:
+
+```bash
+python src/app.py
+```
+
+3. Initialize the database by visiting `http://localhost:5000/init` in your
+browser. You can then add people records with a POST request to `/people` using
+JSON payloads.
+
+Future development will add more functionality, including data ingestion,
+forecasting algorithms, and a user interface.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pysqlite3-binary

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,52 @@
+"""Entry point for the workforce modeling application."""
+
+from flask import Flask, jsonify, request
+
+from database import get_connection, init_db
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    return "Workforce Modeling API"
+
+
+@app.route('/init')
+def init_route():
+    """Initialize the SQLite database with required tables."""
+    init_db()
+    return jsonify({'status': 'initialized'})
+
+
+@app.route('/people', methods=['GET', 'POST'])
+def manage_people():
+    """Create or list people records."""
+    conn = get_connection()
+    cur = conn.cursor()
+    if request.method == 'POST':
+        data = request.get_json(force=True)
+        cur.execute(
+            (
+                "INSERT INTO people (name, grade, location, contract_type, status, start_date, end_date)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                data.get('name'),
+                data.get('grade'),
+                data.get('location'),
+                data.get('contract_type'),
+                data.get('status'),
+                data.get('start_date'),
+                data.get('end_date'),
+            ),
+        )
+        conn.commit()
+    cur.execute("SELECT * FROM people")
+    rows = cur.fetchall()
+    conn.close()
+    return jsonify({'people': rows})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,78 @@
+"""Database utilities for the workforce modeling application."""
+
+import sqlite3
+from sqlite3 import Connection
+
+DATABASE_NAME = 'workforce.db'
+
+
+SCHEMA = [
+    '''
+    CREATE TABLE IF NOT EXISTS people (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        grade TEXT,
+        location TEXT,
+        contract_type TEXT,
+        status TEXT,
+        start_date TEXT,
+        end_date TEXT
+    );
+    ''',
+    '''
+    CREATE TABLE IF NOT EXISTS posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT,
+        start_date TEXT,
+        end_date TEXT,
+        funding_source TEXT,
+        occupant_id INTEGER,
+        FOREIGN KEY(occupant_id) REFERENCES people(id)
+    );
+    ''',
+    '''
+    CREATE TABLE IF NOT EXISTS salary_rates (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        grade TEXT NOT NULL,
+        location TEXT NOT NULL,
+        planning_rate REAL NOT NULL
+    );
+    ''',
+    '''
+    CREATE TABLE IF NOT EXISTS budgets (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        team TEXT,
+        start_date TEXT,
+        end_date TEXT,
+        amount REAL NOT NULL
+    );
+    ''',
+    '''
+    CREATE TABLE IF NOT EXISTS parameters (
+        name TEXT PRIMARY KEY,
+        value TEXT
+    );
+    '''
+]
+
+
+def get_connection():
+    """Return a connection to the SQLite database."""
+    conn = sqlite3.connect(DATABASE_NAME)
+    return conn
+
+
+def init_db(conn: Connection | None = None) -> None:
+    """Create required tables if they do not exist."""
+    close = False
+    if conn is None:
+        conn = get_connection()
+        close = True
+
+    cur = conn.cursor()
+    for ddl in SCHEMA:
+        cur.executescript(ddl)
+    conn.commit()
+
+    if close:
+        conn.close()


### PR DESCRIPTION
## Summary
- expand README with setup notes and project goals
- define SQLite schema and initialization helper
- implement routes for initializing and managing people records

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68483c041e788321b477004384e7bb56