### PR TITLE
Add edit/delete to Manage People

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,61 @@ def manage_people():
         conn.close()
         return render_template("manage_people.html", people=people)
 
+
+@app.route("/edit_person/<int:person_id>", methods=["GET", "POST"])
+def edit_person(person_id):
+    conn = get_db_connection()
+    c = conn.cursor()
+    if request.method == "POST":
+        name = request.form["name"]
+        team = request.form["team"]
+        grade = request.form["grade"]
+        work_stream = request.form["work_stream"]
+        location = request.form["location"]
+        contract_type = request.form["contract_type"]
+        status = request.form["status"]
+        start_date = request.form["start_date"]
+        expected_end_date = request.form["expected_end_date"]
+
+        c.execute(
+            """
+            UPDATE people
+            SET name=?, team=?, grade=?, work_stream=?, location=?,
+                contract_type=?, status=?, start_date=?, expected_end_date=?
+            WHERE person_id=?
+            """,
+            (
+                name,
+                team,
+                grade,
+                work_stream,
+                location,
+                contract_type,
+                status,
+                start_date,
+                expected_end_date,
+                person_id,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return redirect(url_for("manage_people"))
+    else:
+        c.execute("SELECT * FROM people WHERE person_id=?", (person_id,))
+        person = c.fetchone()
+        conn.close()
+        return render_template("edit_person.html", person=person)
+
+
+@app.route("/delete_person/<int:person_id>", methods=["POST"])
+def delete_person(person_id):
+    conn = get_db_connection()
+    c = conn.cursor()
+    c.execute("DELETE FROM people WHERE person_id=?", (person_id,))
+    conn.commit()
+    conn.close()
+    return redirect(url_for("manage_people"))
+
 @app.route("/manage_posts", methods=["GET", "POST"])
 def manage_posts():
     conn = get_db_connection()

--- a/templates/edit_person.html
+++ b/templates/edit_person.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Edit Person</h2>
+  <form method="post">
+    <label>Name: <input type="text" name="name" value="{{ person['name'] }}" required></label><br>
+    <label>Team: <input type="text" name="team" value="{{ person['team'] }}"></label><br>
+    <label>Grade: <input type="text" name="grade" value="{{ person['grade'] }}" required></label><br>
+    <label>Work Stream: <input type="text" name="work_stream" value="{{ person['work_stream'] }}"></label><br>
+    <label>Location: <input type="text" name="location" value="{{ person['location'] }}" required></label><br>
+    <label>Contract Type: <input type="text" name="contract_type" value="{{ person['contract_type'] }}"></label><br>
+    <label>Status: <input type="text" name="status" value="{{ person['status'] }}"></label><br>
+    <label>Start Date (YYYY-MM-DD): <input type="text" name="start_date" value="{{ person['start_date'] }}"></label><br>
+    <label>Expected End Date (YYYY-MM-DD): <input type="text" name="expected_end_date" value="{{ person['expected_end_date'] }}"></label><br>
+    <input type="submit" value="Update Person">
+  </form>
+{% endblock %}

--- a/templates/manage_people.html
+++ b/templates/manage_people.html
@@ -27,6 +27,7 @@
       <th>Status</th>
       <th>Start Date</th>
       <th>Expected End Date</th>
+      <th>Actions</th>
     </tr>
     {% for person in people %}
     <tr>
@@ -40,6 +41,12 @@
       <td>{{ person["status"] }}</td>
       <td>{{ person["start_date"] }}</td>
       <td>{{ person["expected_end_date"] }}</td>
+      <td>
+        <a href="{{ url_for('edit_person', person_id=person['person_id']) }}">Edit</a>
+        <form action="{{ url_for('delete_person', person_id=person['person_id']) }}" method="post" style="display:inline;">
+          <button type="submit" onclick="return confirm('Delete this person?');">Delete</button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
   </table>


### PR DESCRIPTION
## Summary
- implement edit and delete routes in `app.py`
- update Manage People table with actions for editing and deleting
- add template for editing a person

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684850736b90832185f4f2c09db271df