### PR TITLE
Add pay rate management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ reporting tools for human resources teams.
 
 The repository currently contains the following modules:
 
-- `app.py` — Flask server providing pages to manage people, posts and budget data.
+- `app.py` — Flask server providing pages to manage people, posts, budget data and pay rates.
 - `database.py` — utilities for connecting to a SQLite database.
 - `init_db.py` — script to create the required tables.
 - `utils.py` — helper functions used for forecasting and budgeting.
@@ -42,7 +42,8 @@ python app.py
 ```
 
 4. Open `http://localhost:5000/` in your browser and use the navigation links to
-manage records or run a forecast. You can also export the people table to CSV
+manage records or run a forecast. The interface now includes a tab to manage
+monthly pay rates where you can upload or edit rates in bulk. You can also export the people table to CSV
 and generate a monthly cost chart from the interface.
 
 Future development will add more functionality, including data ingestion,

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
         <a href="{{ url_for('manage_people') }}">Manage People</a> |
         <a href="{{ url_for('manage_posts') }}">Manage Posts</a> |
         <a href="{{ url_for('manage_budget') }}">Manage Budget</a> |
+        <a href="{{ url_for('manage_pay') }}">Manage Pay</a> |
         <a href="{{ url_for('run_forecast_route') }}">Run Forecast</a> |
         <a href="{{ url_for('export_csv') }}">Export CSV</a> |
         <a href="{{ url_for('generate_chart') }}">View Chart</a>

--- a/templates/edit_pay.html
+++ b/templates/edit_pay.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Edit Pay Rate</h2>
+  <form method="post">
+    <label>Location: <input type="text" name="location" value="{{ record['location'] }}" required></label><br>
+    <label>Grade: <input type="text" name="grade" value="{{ record['grade'] }}" required></label><br>
+    <label>Date (YYYY-MM): <input type="text" name="date" value="{{ record['year_month'] }}" required></label><br>
+    <label>Pay: <input type="text" name="pay" value="{{ record['monthly_planning_rate'] }}" required></label><br>
+    <input type="submit" value="Update Pay Rate">
+  </form>
+{% endblock %}

--- a/templates/manage_pay.html
+++ b/templates/manage_pay.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Manage Pay Rates</h2>
+  <form method="post">
+    <label>Location: <input type="text" name="location" required></label><br>
+    <label>Grade: <input type="text" name="grade" required></label><br>
+    <label>Date (YYYY-MM): <input type="text" name="date" required></label><br>
+    <label>Pay: <input type="text" name="pay" required></label><br>
+    <input type="submit" value="Add Pay Rate">
+  </form>
+
+  <h3>Bulk Upload</h3>
+  <form action="{{ url_for('upload_pay') }}" method="post" enctype="multipart/form-data">
+    <input type="file" name="csv_file" accept=".csv" required>
+    <input type="submit" value="Upload CSV">
+  </form>
+  <p><a href="{{ url_for('download_pay_template') }}">Download template CSV</a></p>
+
+  <h3>Current Pay Rates</h3>
+  <table border="1">
+    <tr>
+      <th>ID</th>
+      <th>Location</th>
+      <th>Grade</th>
+      <th>Date</th>
+      <th>Pay</th>
+      <th>Actions</th>
+    </tr>
+    {% for row in salaries %}
+    <tr>
+      <td>{{ row["salary_id"] }}</td>
+      <td>{{ row["location"] }}</td>
+      <td>{{ row["grade"] }}</td>
+      <td>{{ row["year_month"] }}</td>
+      <td>{{ row["monthly_planning_rate"] }}</td>
+      <td>
+        <a href="{{ url_for('edit_pay', salary_id=row['salary_id']) }}">Edit</a>
+        <form action="{{ url_for('delete_pay', salary_id=row['salary_id']) }}" method="post" style="display:inline;">
+          <button type="submit" onclick="return confirm('Delete this record?');">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Manage Pay tab in navigation
- implement CRUD views for salaries table
- support CSV template download and bulk upload
- document new pay rate page in README

## Testing
- `python -m py_compile app.py utils.py database.py init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6848953fc62883218cddb11c3cb73582