### PR TITLE
Add CSV bulk upload options to all management pages

### DIFF
--- a/templates/manage_budget.html
+++ b/templates/manage_budget.html
@@ -8,6 +8,13 @@
     <label>Allocated Budget: <input type="text" name="allocated_budget" required></label><br>
     <input type="submit" value="Add Budget">
   </form>
+
+  <h3>Bulk Upload</h3>
+  <form action="{{ url_for('upload_budget') }}" method="post" enctype="multipart/form-data">
+    <input type="file" name="csv_file" accept=".csv" required>
+    <input type="submit" value="Upload CSV">
+  </form>
+  <p><a href="{{ url_for('download_budget_template') }}">Download template CSV</a></p>
   
   <h3>Current Budget Records</h3>
   <table border="1">

--- a/templates/manage_people.html
+++ b/templates/manage_people.html
@@ -13,6 +13,13 @@
     <label>Expected End Date (YYYY-MM-DD): <input type="text" name="expected_end_date"></label><br>
     <input type="submit" value="Add Person">
   </form>
+
+  <h3>Bulk Upload</h3>
+  <form action="{{ url_for('upload_people') }}" method="post" enctype="multipart/form-data">
+    <input type="file" name="csv_file" accept=".csv" required>
+    <input type="submit" value="Upload CSV">
+  </form>
+  <p><a href="{{ url_for('download_people_template') }}">Download template CSV</a></p>
   
   <h3>Current People</h3>
   <table border="1">

--- a/templates/manage_posts.html
+++ b/templates/manage_posts.html
@@ -9,6 +9,13 @@
     <label>Person ID (optional): <input type="text" name="person_id"></label><br>
     <input type="submit" value="Add Post">
   </form>
+
+  <h3>Bulk Upload</h3>
+  <form action="{{ url_for('upload_posts') }}" method="post" enctype="multipart/form-data">
+    <input type="file" name="csv_file" accept=".csv" required>
+    <input type="submit" value="Upload CSV">
+  </form>
+  <p><a href="{{ url_for('download_posts_template') }}">Download template CSV</a></p>
   
   <h3>Current Posts</h3>
   <table border="1">


### PR DESCRIPTION
## Summary
- enable CSV template download and upload for people, posts and budget data
- add bulk upload forms to the respective templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848973d4e148321a7f4963a9a228636